### PR TITLE
[ GEN-9 ] Add auth/login screen/restrict POST request authenticated only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *$py.class
 
 *.pyc
+.vscode/
 
 node_modules
 

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'accounts'

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/accounts/serializer.py
+++ b/accounts/serializer.py
@@ -1,0 +1,34 @@
+from rest_framework import serializers
+from django.contrib.auth.models import User
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.validators import UniqueValidator
+from django.contrib.auth.password_validation import validate_password
+
+# referenced from https://www.codersarts.com/post/how-to-create-register-and-login-api-using-django-rest-framework-and-token-authentication
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'email')
+
+
+class RegisterSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField(
+        required=True,
+        validators=[UniqueValidator(queryset=User.objects.all())]
+    )
+    password = serializers.CharField(
+        write_only=True, required=True, validators=[validate_password])
+
+    class Meta:
+        model = User
+        fields = ('username', 'password', 'email')
+
+    def create(self, validated_data):
+        user = User.objects.create(
+            username=validated_data['username'],
+            email=validated_data['email'],
+        )
+        user.set_password(validated_data['password'])
+        user.save()
+        return user

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,0 +1,42 @@
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+from rest_framework import status
+
+
+class AuthenticationTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser', password='testpassword')
+        self.token = Token.objects.create(user=self.user)
+
+    def test_login(self):
+        url = '/auth/token/'
+        data = {'username': 'testuser', 'password': 'testpassword'}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('access', response.data)
+
+    def test_authenticated_endpoint(self):
+        url = '/auth/user-details/'
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class RegisterUserAPIViewTestCase(APITestCase):
+    url = '/auth/register/'
+
+    def test_register_user(self):
+        data = {
+            'username': 'testuser',
+            'email': 'test@example.com',
+            'password': 'testpassword',
+        }
+
+        response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        user = User.objects.get(username='testuser')
+        self.assertIsNotNone(user)
+        self.assertEqual(user.email, 'test@example.com')

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from .views import UserDetailAPI, RegisterUserAPIView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
+urlpatterns = [
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('user-details/', UserDetailAPI.as_view()),
+    path('register/', RegisterUserAPIView.as_view()),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,0 +1,22 @@
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from .serializer import UserSerializer, RegisterSerializer
+from django.contrib.auth.models import User
+from rest_framework.authentication import TokenAuthentication
+from rest_framework import generics
+
+# referenced from https://www.codersarts.com/post/how-to-create-register-and-login-api-using-django-rest-framework-and-token-authentication
+class UserDetailAPI(APIView):
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, *args, **kwargs):
+        user = User.objects.get(id=request.user.id)
+        serializer = UserSerializer(user)
+        return Response(serializer.data)
+
+
+class RegisterUserAPIView(generics.CreateAPIView):
+    permission_classes = (AllowAny,)
+    serializer_class = RegisterSerializer

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "vue": "^3.3.4",
         "vue-color-input": "^1.0.8",
         "vue-router": "^4.2.2",
+        "vue-styled-components": "^1.6.0",
         "vue3-styled-components": "^1.2.1",
         "yarn": "^1.22.19"
       },
@@ -36,7 +37,7 @@
         "eslint-plugin-vue": "^8.0.3",
         "jquery": "^3.7.0",
         "popper.js": "^1.16.1",
-        "prettier": "2.8.8",
+        "prettier": "^2.8.8",
         "typescript": "~4.5.5"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
     "vue": "^3.3.4",
     "vue-color-input": "^1.0.8",
     "vue-router": "^4.2.2",
-    "vue-styled-components": "^1.6.0",
     "vue3-styled-components": "^1.2.1",
     "yarn": "^1.22.19"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-vue": "^8.0.3",
     "jquery": "^3.7.0",
     "popper.js": "^1.16.1",
-    "prettier": "2.8.8",
+    "prettier": "^2.8.8",
     "typescript": "~4.5.5"
   },
   "browserslist": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-vue": "^8.0.3",
     "jquery": "^3.7.0",
     "popper.js": "^1.16.1",
-    "prettier": "^2.8.8",
+    "prettier": "2.8.8",
     "typescript": "~4.5.5"
   },
   "browserslist": [

--- a/frontend/src/GameModule/CreateNewGame/components/CreateNewGame.vue
+++ b/frontend/src/GameModule/CreateNewGame/components/CreateNewGame.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
-import axios from 'axios';
+import axios from '@/axios-instance';
 
 type ComponentData = {
   form: {

--- a/frontend/src/GameModule/Gacha/components/GameView.vue
+++ b/frontend/src/GameModule/Gacha/components/GameView.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defineComponent, inject, provide, reactive } from 'vue';
 import GachaResult from './GachaResult.vue';
-import axios from 'axios';
+import axios from '@/axios-instance';
 import { Game } from '@GameModule/models/Game';
 import { SelectedGameKey } from '@/symbols';
 import { RaritiesHashKey } from '../symbols';
@@ -68,7 +68,7 @@ export default defineComponent({
         return;
       }
       axios
-        .get(`/game/rarities/`, { params: { game: this.selectedGame.id } })
+        .get(`/game/rarities/`, { params: { game_id: this.selectedGame.id } })
         .then((response) => {
           const raritiesHash = response.data.reduce((acc, curr) => {
             if (curr.pity != 0) {

--- a/frontend/src/ItemModule/CreateNewItem/components/CreateNewItem.vue
+++ b/frontend/src/ItemModule/CreateNewItem/components/CreateNewItem.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Game } from '@GameModule/models/Game';
 import { Rarity, RarityId } from '@RarityModule/models/Rarity';
-import axios from 'axios';
+import axios from '@/axios-instance';
 import { defineComponent } from 'vue';
 import keyBy from 'lodash/keyBy';
 

--- a/frontend/src/ItemModule/CreateNewItem/components/CreateNewItem.vue
+++ b/frontend/src/ItemModule/CreateNewItem/components/CreateNewItem.vue
@@ -58,7 +58,7 @@ export default defineComponent({
         return;
 
       const formData = new FormData();
-      formData.append('rate', this.form.rarityId.toString());
+      formData.append('rarity_id', this.form.rarityId.toString());
       formData.append('item_name', this.form.itemName);
       formData.append('image', this.form.selectedImage);
       formData.append('chance', Number(this.form.chance).toString());

--- a/frontend/src/RarityModule/CreateNewRarity/components/CreateNewRarity.vue
+++ b/frontend/src/RarityModule/CreateNewRarity/components/CreateNewRarity.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { Game } from '@GameModule/models/Game';
-import axios from 'axios';
+import axios from '@/axios-instance';
 import { defineComponent } from 'vue';
 import keyBy from 'lodash/keyBy';
 

--- a/frontend/src/axios-instance.ts
+++ b/frontend/src/axios-instance.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+const instance = axios.create({
+  baseURL: 'http://127.0.0.1:8000',
+});
+
+// Add an interceptor to include the access token in the request headers
+instance.interceptors.request.use((config) => {
+  const accessToken = localStorage.getItem('accessToken');
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+export default instance;

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -56,6 +56,11 @@ export default defineComponent({
           <a class="nav-link"> Create New </a>
         </router-link>
       </li>
+      <li class="nav-item">
+        <router-link to="/login">
+          <a class="nav-link"> Login </a>
+        </router-link>
+      </li>
     </ul>
   </nav>
 </template>

--- a/frontend/src/components/UserAuth.vue
+++ b/frontend/src/components/UserAuth.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <input v-model="username" placeholder="Username" />
+    <input v-model="password" placeholder="Password" type="password" />
+    <button @click="login">Login</button>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  name: 'UserAuth',
+  data() {
+    return {
+      username: '',
+      password: '',
+    };
+  },
+  methods: {
+    login() {
+      axios
+        .post('/auth/token/', {
+          username: this.username,
+          password: this.password,
+        })
+        .then((response) => {
+          // Save the access token in local storage or Vuex store
+          const accessToken = response.data.access;
+          localStorage.setItem('accessToken', accessToken);
+          console.log('authorized');
+          console.log(accessToken);
+          // Redirect or perform other actions after successful login
+          // ...
+        })
+        .catch((error) => {
+          // Handle login error
+          console.error(error);
+        });
+    },
+  },
+};
+</script>

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -4,6 +4,7 @@ import CreateNewItem from '@ItemModule/CreateNewItem/components/CreateNewItem.vu
 import CreateNewRarity from '@RarityModule/CreateNewRarity/components/CreateNewRarity.vue';
 import CreateNewGame from '@GameModule/CreateNewGame/components/CreateNewGame.vue';
 import GameView from '@GameModule/Gacha/components/GameView.vue';
+import UserAuth from './components/UserAuth.vue';
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -15,5 +16,6 @@ export const router = createRouter({
     { path: '/create/item', component: CreateNewItem },
     { path: '/create/game', component: CreateNewGame },
     { path: '/create/rarity', component: CreateNewRarity },
+    { path: '/login', component: UserAuth },
   ],
 });

--- a/gachasim/settings.py
+++ b/gachasim/settings.py
@@ -27,6 +27,7 @@ SECRET_KEY = 'django-insecure-#f8p9z04x$!h7%2da@^5_$x@s08&oz-_@p12g*7uh#kpv%wk!p
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+# TODO: change this to not allow all
 ALLOWED_HOSTS=['*']
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/gachasim/settings.py
+++ b/gachasim/settings.py
@@ -44,7 +44,9 @@ INSTALLED_APPS = [
     'colorfield',
     'django_filters',
     'rest_framework',
+    'rest_framework.authtoken',
     'corsheaders',
+    'knox',
 ]
 
 MIDDLEWARE = [
@@ -78,6 +80,9 @@ TEMPLATES = [
 
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ],
 }
 
 WSGI_APPLICATION = 'gachasim.wsgi.application'

--- a/gachasim/urls.py
+++ b/gachasim/urls.py
@@ -22,6 +22,7 @@ from django.conf import settings
 urlpatterns = [
     path("game/", include("game.urls")),
     path('admin/', admin.site.urls),
+    path('auth/', include("accounts.urls"))
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/game/tests.py
+++ b/game/tests.py
@@ -1,3 +1,73 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
 
-# Create your tests here.
+
+class ItemViewSetTestCase(APITestCase):
+    url = '/game/items/'
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser', password='testpassword')
+
+    def test_unauthenticated_users_can_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unauthenticated_users_cannot_create_items(self):
+        response = self.client.post(
+            self.url, {'name': 'Test Item'}, format='json')
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_users_can_create_items(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.url, {'name': 'Test Item'}, format='json')
+        self.assertNotEqual(response.status_code, 403)
+
+
+class RarityViewSetTestCase(APITestCase):
+    url = '/game/rarities/'
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser', password='testpassword')
+
+    def test_unauthenticated_users_can_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unauthenticated_users_cannot_create_items(self):
+        response = self.client.post(
+            self.url, {'name': 'Test Item'}, format='json')
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_users_can_create_items(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.url, {'name': 'Test Item'}, format='json')
+        self.assertNotEqual(response.status_code, 403)
+
+
+class GameViewSetTestCase(APITestCase):
+    url = '/game/games/'
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser', password='testpassword')
+
+    def test_unauthenticated_users_can_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unauthenticated_users_cannot_create_items(self):
+        response = self.client.post(
+            self.url, {'name': 'Test Item'}, format='json')
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_users_can_create_items(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.url, {'name': 'Test Item'}, format='json')
+        self.assertNotEqual(response.status_code, 403)

--- a/game/views.py
+++ b/game/views.py
@@ -92,7 +92,7 @@ class GameViewSet(viewsets.ModelViewSet):
 
 class Gacha(APIView):
     populated = False
-    game = -1
+    game_id = -1
     pity = dict()
     choices = []
     weights = []
@@ -117,13 +117,12 @@ class Gacha(APIView):
 
     def populate(self, game_id):
         game = get_object_or_404(Game, pk=game_id)
-        if game_id != self.game:
+        if game_id != self.game_id:
             self.reset()
-            self.game = game_id
+            self.game_id = game_id
         rarities = game.rarity_set.all()
 
         for rarity in rarities:
-            print(rarity.id)
             self.raritylookup[rarity.id] = rarity
             self.choices.append(rarity.id)
             self.weights.append(rarity.chance)

--- a/game/views.py
+++ b/game/views.py
@@ -97,7 +97,7 @@ class Gacha(APIView):
     choices = []
     weights = []
     currpity = dict()
-    raritylookup = dict()
+    rarityByIdHash = dict()
     softpity = dict()
     softpitychance = dict()
     itemLookup = dict()
@@ -109,7 +109,7 @@ class Gacha(APIView):
         self.choices = []
         self.weights = []
         self.currpity = dict()
-        self.raritylookup = dict()
+        self.rarityByIdHash = dict()
         self.softpity = dict()
         self.softpitychance = dict()
         self.itemLookup = dict()
@@ -123,7 +123,7 @@ class Gacha(APIView):
         rarities = game.rarity_set.all()
 
         for rarity in rarities:
-            self.raritylookup[rarity.id] = rarity
+            self.rarityByIdHash[rarity.id] = rarity
             self.choices.append(rarity.id)
             self.weights.append(rarity.chance)
             if rarity.pity != 0:
@@ -202,15 +202,15 @@ class Gacha(APIView):
         if not self.populated:
             self.populate(game_id)
         # if one of the data structures not populated, cannot roll.
-        if not self.raritylookup or not self.itemLookup:
+        if not self.rarityByIdHash or not self.itemLookup:
             return Response([])
         numrolls = int(request.GET.get('numrolls', ''))
         res = []
         for i in range(numrolls):
-            rarity = self.roll()
-            roll = RaritySerializer(self.raritylookup[rarity]).data
-            item = ItemSerializer(self.get_item(rarity)).data
-            res.append({"rarity": roll, "item": item,
+            rarity_id = self.roll()
+            rarity = RaritySerializer(self.rarityByIdHash[rarity_id]).data
+            item = ItemSerializer(self.get_item(rarity_id)).data
+            res.append({"rarity": rarity, "item": item,
                        "pity": self.currpity.copy()})
 
         return Response(res)


### PR DESCRIPTION
- add accounts app in backend (everything to do with user authentication)
- `/auth/login`: allows users to log in
- `/auth/token` / `auth/token/refresh/`: endpoint for acquiring token
- restrict POST requests for `/game/items/`, `/game/rarities/`, `/game/games/` to authenticated users only. GET requests are open to everyone
- add axios-instance: modifies request headers if token found in localstorage - we can look for a more secure way later. Use this for now

TESTING
- add unit tests to test unauthenticated users cannot make post but can make GET
- registered users manually (`http://127.0.0.1:8000/auth/register/`), used login form to get localstorage token, then was able to make POST requests for publishing new items/games/rarities